### PR TITLE
Introduce types around Packages/Paths

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -73,14 +73,14 @@ func scanReader(reader io.Reader) ([]string, error) {
 	return results, scanner.Err()
 }
 
-//CmdError is returned when an exit error is encountered.
+//Error is returned when an exit error is encountered.
 //It also captures the stderr lines from the command.
-type CmdError struct {
+type Error struct {
 	Exit   *exec.ExitError
 	StdErr []string
 }
 
-func (s *CmdError) Error() string {
+func (s *Error) Error() string {
 	stderr := strings.Join(s.StdErr, "\n")
 	if stderr != "" {
 		return stderr
@@ -91,7 +91,7 @@ func (s *CmdError) Error() string {
 
 func newCmdError(err error, stderr []string) error {
 	if exitErr, ok := err.(*exec.ExitError); ok {
-		return &CmdError{exitErr, stderr}
+		return &Error{exitErr, stderr}
 	}
 
 	return err

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -23,7 +23,7 @@ func TestCmdError(t *testing.T) {
 		t.Errorf("Should have error")
 	}
 
-	if _, ok := err.(*CmdError); !ok {
+	if _, ok := err.(*Error); !ok {
 		t.Errorf("Should be CmdError: %v", err)
 	}
 }

--- a/cove.go
+++ b/cove.go
@@ -21,11 +21,11 @@ import (
 //Package is a specific and unique go package
 type Package string
 
-//Path is a path to search for packages in.  It can correlate to 0 to many Packages
-type Path string
+//PackagePattern is a pattern, potentially with wildcards, to search for packages in.  It can correlate to 0 to many Packages
+type PackagePattern string
 
-//PathsAsStrings takes a slice of paths and returns a slice of strings
-func PathsAsStrings(paths []Path) []string {
+//PackagePatternsAsStrings takes a slice of paths and returns a slice of strings
+func PackagePatternsAsStrings(paths []PackagePattern) []string {
 	var returns []string
 	for _, path := range paths {
 		returns = append(returns, string(path))
@@ -54,11 +54,11 @@ func PackagesFromStrings(str []string) []Package {
 	return returns
 }
 
-//PathsFromStrings creates a slice of paths from a slice of strings
-func PathsFromStrings(str []string) []Path {
-	var returns []Path
+//PackagePatternsFromStrings creates a slice of paths from a slice of strings
+func PackagePatternsFromStrings(str []string) []PackagePattern {
+	var returns []PackagePattern
 	for _, s := range str {
-		returns = append(returns, Path(s))
+		returns = append(returns, PackagePattern(s))
 	}
 
 	return returns
@@ -120,8 +120,8 @@ type missing struct {
 // Packages gets all packages that match any of the paths.
 // The package list will only contain 1 entry per package in sorted order.
 // Invalid paths will generate an error, but will not stop the evaluation of the other paths.
-func Packages(paths ...Path) ([]Package, error) {
-	packs, err := cmd.Output(GoCmd("list", PathsAsStrings(paths)...))
+func Packages(paths ...PackagePattern) ([]Package, error) {
+	packs, err := cmd.Output(GoCmd("list", PackagePatternsAsStrings(paths)...))
 	sort.Strings(packs)
 	return PackagesFromStrings(packs), err
 }

--- a/cove.go
+++ b/cove.go
@@ -18,6 +18,52 @@ import (
 	"github.com/MediaMath/cove/cmd"
 )
 
+//Package is a specific and unique go package
+type Package string
+
+//Path is a path to search for packages in.  It can correlate to 0 to many Packages
+type Path string
+
+//PathsAsStrings takes a slice of paths and returns a slice of strings
+func PathsAsStrings(paths []Path) []string {
+	var returns []string
+	for _, path := range paths {
+		returns = append(returns, string(path))
+	}
+
+	return returns
+}
+
+//PackagesAsStrings takes a slice of packages and returns a slice of strings
+func PackagesAsStrings(packs []Package) []string {
+	var returns []string
+	for _, pack := range packs {
+		returns = append(returns, string(pack))
+	}
+
+	return returns
+}
+
+//PackagesFromStrings creates a slice of packages from a slice of strings
+func PackagesFromStrings(str []string) []Package {
+	var returns []Package
+	for _, s := range str {
+		returns = append(returns, Package(s))
+	}
+
+	return returns
+}
+
+//PathsFromStrings creates a slice of paths from a slice of strings
+func PathsFromStrings(str []string) []Path {
+	var returns []Path
+	for _, s := range str {
+		returns = append(returns, Path(s))
+	}
+
+	return returns
+}
+
 //GoCmd takes the sub and args and prepares a command like 'go sub arg1 arg2...'
 func GoCmd(sub string, args ...string) *exec.Cmd {
 	arguments := append([]string{sub}, args...)
@@ -25,19 +71,19 @@ func GoCmd(sub string, args ...string) *exec.Cmd {
 }
 
 // Get runs 'go get pack'
-func Get(pack string) error {
-	return cmd.Run(GoCmd("get", pack))
+func Get(pack Package) error {
+	return cmd.Run(GoCmd("get", string(pack)))
 }
 
 // PackageExists checks to see if a given package name exists
-func PackageExists(pack string) bool {
-	err := cmd.Run(GoCmd("list", pack))
+func PackageExists(pack Package) bool {
+	err := cmd.Run(GoCmd("list", string(pack)))
 	return err == nil
 }
 
 // MissingDependencies returns any go packages that are missing for a given package.
-func MissingDependencies(pack string) ([]string, error) {
-	var deps []string
+func MissingDependencies(pack Package) ([]Package, error) {
+	var deps []Package
 	var parsed missing
 	if err := PackageJSON(pack, &parsed); err != nil {
 		return deps, err
@@ -46,18 +92,18 @@ func MissingDependencies(pack string) ([]string, error) {
 	return missingFromParsed(&parsed)
 }
 
-func missingFromParsed(parsed *missing) ([]string, error) {
+func missingFromParsed(parsed *missing) ([]Package, error) {
 	if !parsed.Incomplete {
-		return []string{}, nil
+		return []Package{}, nil
 	}
 
 	seen := make(map[string]bool)
-	var missing []string
+	var missing []Package
 	for _, errs := range parsed.DepsErrors {
 		for _, imports := range errs.ImportStack {
 			if _, contains := seen[imports]; !contains {
 				seen[imports] = true
-				missing = append(missing, imports)
+				missing = append(missing, Package(imports))
 			}
 		}
 	}
@@ -74,16 +120,16 @@ type missing struct {
 // Packages gets all packages that match any of the paths.
 // The package list will only contain 1 entry per package in sorted order.
 // Invalid paths will generate an error, but will not stop the evaluation of the other paths.
-func Packages(paths ...string) ([]string, error) {
-	packs, err := cmd.Output(GoCmd("list", paths...))
+func Packages(paths ...Path) ([]Package, error) {
+	packs, err := cmd.Output(GoCmd("list", PathsAsStrings(paths)...))
 	sort.Strings(packs)
-	return packs, err
+	return PackagesFromStrings(packs), err
 }
 
 // PackageJSON takes a SINGLE fully qualified package import path and decodes the 'go list -json' response.
 // See $GOROOT/src/cmd/go/list.go for documentation on the json output.
-func PackageJSON(pack string, v interface{}) error {
-	return cmd.PipeWith(GoCmd("list", "-json", pack), func(stdout io.Reader) error {
+func PackageJSON(pack Package, v interface{}) error {
+	return cmd.PipeWith(GoCmd("list", "-json", string(pack)), func(stdout io.Reader) error {
 		return json.NewDecoder(stdout).Decode(v)
 	})
 }
@@ -92,14 +138,14 @@ func PackageJSON(pack string, v interface{}) error {
 // The file is created in outdir.  The parameter short sets whether to run
 // all tests or only the short ones. The mode specifies which style of cover mode is used.
 // If a profile is able to be created its file name is returned.
-func CoverageProfile(short bool, mode string, outdir string, pack string) (string, error) {
+func CoverageProfile(short bool, mode string, outdir string, pack Package) (string, error) {
 	if direrr := os.MkdirAll(outdir, 0744); direrr != nil {
 		return "", direrr
 	}
 
 	profile := getProfileFileName(outdir, pack)
 
-	if err := cmd.Run(GoCmd("test", pack, fmt.Sprintf("-covermode=%s", mode), fmt.Sprintf("-coverprofile=%s", profile), getShort(short))); err != nil {
+	if err := cmd.Run(GoCmd("test", string(pack), fmt.Sprintf("-covermode=%s", mode), fmt.Sprintf("-coverprofile=%s", profile), getShort(short))); err != nil {
 		return "", fmt.Errorf("%s:%v:%v", pack, err, profile)
 	}
 
@@ -128,8 +174,8 @@ func getReportFileName(profile string, outdir string) string {
 	return fmt.Sprintf("%s.html", fullPath)
 }
 
-func getProfileFileName(outdir string, pack string) string {
-	profile := strings.Replace(pack, "/", ".", -1)
+func getProfileFileName(outdir string, pack Package) string {
+	profile := strings.Replace(string(pack), "/", ".", -1)
 	fullPath := filepath.Join(outdir, profile)
 	return fmt.Sprintf("%s.out", fullPath)
 }

--- a/cvr/main.go
+++ b/cvr/main.go
@@ -36,7 +36,7 @@ func main() {
 		paths = append(paths, ".")
 	}
 
-	packs, pathErr := cove.Packages(cove.PathsFromStrings(paths)...)
+	packs, pathErr := cove.Packages(cove.PackagePatternsFromStrings(paths)...)
 	logError(pathErr)
 
 	anyCoverage := false

--- a/cvr/main.go
+++ b/cvr/main.go
@@ -36,7 +36,7 @@ func main() {
 		paths = append(paths, ".")
 	}
 
-	packs, pathErr := cove.Packages(paths...)
+	packs, pathErr := cove.Packages(cove.PathsFromStrings(paths)...)
 	logError(pathErr)
 
 	anyCoverage := false

--- a/gosh/main.go
+++ b/gosh/main.go
@@ -34,21 +34,23 @@ func main() {
 	}
 }
 
-func getMap(args []string) (map[string]string, error) {
-	goshMap := make(map[string]string)
+type packToLocation map[cove.Package]string
+
+func getMap(args []string) (packToLocation, error) {
+	goshMap := make(packToLocation)
 	for _, arg := range args {
 		pair := strings.Split(arg, ",")
 		if len(pair) != 2 {
 			return nil, fmt.Errorf("Arguments are unparseable: %v", strings.Join(args, " "))
 		}
 
-		goshMap[pair[0]] = pair[1]
+		goshMap[cove.Package(pair[0])] = pair[1]
 	}
 
 	return goshMap, nil
 }
 
-func gosh(overwrite bool, goshMap map[string]string) bool {
+func gosh(overwrite bool, goshMap packToLocation) bool {
 	hadError := false
 	for pack, location := range goshMap {
 
@@ -74,7 +76,7 @@ func gosh(overwrite bool, goshMap map[string]string) bool {
 	return hadError
 }
 
-func getDependencies(goshMap map[string]string, dependencies []string) bool {
+func getDependencies(goshMap packToLocation, dependencies []cove.Package) bool {
 	hadError := false
 	for _, dep := range dependencies {
 		if _, inGoshMap := goshMap[dep]; inGoshMap {
@@ -109,8 +111,8 @@ func vcsClone(src string, destination string) error {
 	return cmd.Run(exec.Command("git", "clone", "--depth=1", src, destination))
 }
 
-func to(pack string) string {
-	return filepath.Join(os.Getenv("GOPATH"), "src", pack)
+func to(pack cove.Package) string {
+	return filepath.Join(os.Getenv("GOPATH"), "src", string(pack))
 }
 
 func overwrite(destination string, copyTo func(string) error) error {

--- a/missing_test.go
+++ b/missing_test.go
@@ -46,7 +46,9 @@ func TestHasMissing(t *testing.T) {
 	}
 }
 
-func has(miss []string, dep ...string) error {
+func has(packs []Package, dep ...string) error {
+	miss := PackagesAsStrings(packs)
+
 	if len(miss) < len(dep) {
 		return fmt.Errorf("Expected is missing items:%v %v", miss, dep)
 	}
@@ -66,10 +68,10 @@ func has(miss []string, dep ...string) error {
 	return nil
 }
 
-func parseString(toParse string) ([]string, error) {
+func parseString(toParse string) ([]Package, error) {
 	var parsed missing
 	if err := json.NewDecoder(strings.NewReader(toParse)).Decode(&parsed); err != nil {
-		return []string{}, err
+		return []Package{}, err
 	}
 
 	return missingFromParsed(&parsed)


### PR DESCRIPTION
Was getting confused around path/package distinction so added type aliases.  In scala or another language with a non-garbage type system this would be a no brainer.  Not sure about in go.  Thoughts @bhand-mm @wheaties @logie17?