### PR TITLE
Fix handling of GOPATH with multi-values.

### DIFF
--- a/gosh/gosh_test.go
+++ b/gosh/gosh_test.go
@@ -4,7 +4,10 @@ package main
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestGetGoshMapFromArgs(t *testing.T) {
 	goshMap, _ := getMap([]string{"foo/bar,git@github.com/MediaMath/foo.git", "salt,git@github.com/MediaMath/salt.git"})
@@ -90,4 +93,17 @@ func TestSingleParamImplicationFails(t *testing.T) {
 	if _, singleParam := impliedGithubRepo("foo"); singleParam == nil {
 		t.Errorf("Didnt get error on only host")
 	}
+}
+
+func TestToSingleAndMultiGoPath(t *testing.T) {
+	os.Setenv("GOPATH", "/foo/bar:/local/foo/bar")
+	if path := to(&Location{"github.com", "/projecta"}); path != "/foo/bar/src/projecta" {
+		t.Errorf("Didn't get the correct to path from to for a multi-path: %s", path)
+	}
+
+	os.Setenv("GOPATH", "/single/path")
+	if path := to(&Location{"github.com", "/projecta"}); path != "/single/path/src/projecta" {
+		t.Errorf("Didn't get the correct to path from to for a single path: %s", path)
+	}
+
 }

--- a/gosh/main.go
+++ b/gosh/main.go
@@ -164,7 +164,7 @@ func vcsClone(src string, destination string) error {
 }
 
 func to(location *Location) string {
-	return filepath.Join(os.Getenv("GOPATH"), "src", location.Path)
+	return filepath.Join(strings.Split(os.Getenv("GOPATH"), ":")[0], "src", location.Path)
 }
 
 func overwrite(destination string, copyTo func(string) error) error {


### PR DESCRIPTION
When using gvm it can setup a $GOPATH as the following:

GOPATH=/apps/we/are/not/in/oz:/apps/somewhere/over/the/rainbow.gvm_local/pkgsets/go1.4/local:/apps/golang/gvm/pkgsets/go1.4/global

Gosh currently does not support this sort of string and will throw a
strange error like the following:

"2015/05/08 21:25:43 Could not determine missing dependencies for
github.com/oz/the/man/behind/the/curtain: Cannot get json for
'github.com/oz/the/main/behind/the/curtain' as it is not a go package. Original
error: EOF"

This fix should allow both single and multi values. It operates the same
as "go get" does in that it uses the first value in the list [0] when
installing the go dep.